### PR TITLE
fixed document upload headers for strict HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 api/*.pyc
+api/c2mAPI.pyc


### PR DESCRIPTION
/documents API sends Multipart/Formdata headers with a mix of file and data. To comply with strict HTTPS, this requires the specialized python class MultipartEncode from the toolbelt module:
https://toolbelt.readthedocs.io/en/latest/user.html